### PR TITLE
fix: remove docker-compose PyPI dependency

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,6 @@ RUN pip install --upgrade \
 RUN pip install --upgrade \
 	awscli \
 	"datadog==0.35.0" \
-	"docker-compose==1.29.2" \
 	"pyjwt>=1.6.0" \
 	"https://github.com/skip-pay/developers-chamber/tarball/${DOCKER_TAG}"
 


### PR DESCRIPTION
This is no longer needed as `docker compose`. Is preferred and has compatible API and `docker-compose` alias.