### PR TITLE
Improve migrations regex

### DIFF
--- a/developers_chamber/utils.py
+++ b/developers_chamber/utils.py
@@ -8,7 +8,7 @@ from click import ClickException
 from git import Repo
 
 LOGGER = logging.getLogger()
-MIGRATIONS_PATTERN = r'migrations\/([^\/]+)\.py$'
+MIGRATIONS_PATTERN = r'migrations\/\d+_migration\.py'
 
 
 def call_command(command, quiet=False, env=None):


### PR DESCRIPTION
I need skip `__init__.py` files in migrations directories