### PR TITLE
Removing isort from qa all check

### DIFF
--- a/developers_chamber/scripts/qa.py
+++ b/developers_chamber/scripts/qa.py
@@ -21,7 +21,6 @@ def all():
         MissingMigrationsQACheck(),
         MigrationFilenamesQACheck(),
         MissingTranslationsQACheck(),
-        ImportOrderQACheck(),
         TestMethodNamesQACheck(),
     ).run()
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='skip-developers-chamber',
-    version='1.0.1',
+    version='1.1.0',
     description='A small plugin which help with development, deployment, git',
     keywords='django, skripts, easy live, git, bitbucket, Jira',
     author='Druids team',


### PR DESCRIPTION
We are moving isort check from `qa all` to `pre-commit-hook`