### PR TITLE
Update create-release-branch process

### DIFF
--- a/developers_chamber/scripts/git.py
+++ b/developers_chamber/scripts/git.py
@@ -46,9 +46,7 @@ def create_release_branch(release_type, file, remote_name, branch_name):
         raise click.BadParameter('build is not allowed for release')
     click.echo(
         'New release branch "{}" was created'.format(
-            create_release_branch_func(
-                get_next_version(release_type, None, file), release_type, remote_name, branch_name
-            )
+            create_release_branch_func(file, release_type, remote_name, branch_name)
         )
     )
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,7 @@ RUN apk update && \
 	apk add \
 	bash \
 	curl \
+	jq \
 	gcc \
 	gettext \
 	git \


### PR DESCRIPTION
This PR contains the refactorization of the update create-release-branch command.

1. Updates repository by running git fetch --tags --force. 
2. Ensures that latest tag that we use will be updated as expected.
3. version.json is parsed inside create_release_branch to ensure version is bumped after checkout.
4. Adds `jq` utility to the docker image. It is extremly convenient for parsing `json` from shell scripts.