### PR TITLE
Update migration upload to our current releasing process

### DIFF
--- a/developers_chamber/slack_utils.py
+++ b/developers_chamber/slack_utils.py
@@ -13,9 +13,10 @@ class RecentMigrationsSlackUploader(RepoMixin):
         self.target_branch = target_branch
         self.migrations_pattern = r'{}'.format(migrations_pattern)
         self.active_branch = self._get_active_branch_name()
+        self.repo = self._get_repo()
 
     def _get_migration_files(self):
-        return [diff.b_path for diff in self._get_diffs(target_branch=self.target_branch)
+        return [diff.b_path for diff in self.repo.commit(self.target_branch).diff(self.active_branch, create_patch=True)
                 if diff.new_file and re.search(self.migrations_pattern, diff.b_path)]
 
     def send_message(self, msg):

--- a/developers_chamber/utils.py
+++ b/developers_chamber/utils.py
@@ -8,7 +8,7 @@ from click import ClickException
 from git import Repo
 
 LOGGER = logging.getLogger()
-MIGRATIONS_PATTERN = r'migrations\/([^\/]+)\.py$'
+MIGRATIONS_PATTERN = r'\d+_migration\.py$'
 
 
 def call_command(command, quiet=False, env=None):


### PR DESCRIPTION
1. I updated migration regex to a simpler version - simple regex, simple life.
2. I changed the way the diff is computed between branches. Before the diff was computed between the base commit of two branches and the target branch. Now the diff is computed directly between these two branches - simple diff, simple life.